### PR TITLE
Fix ChannelUri SetMedia pointer receiver

### DIFF
--- a/aeron/channeluri.go
+++ b/aeron/channeluri.go
@@ -130,7 +130,7 @@ func (uri *ChannelUri) SetPrefix(prefix string) {
 	uri.prefix = prefix
 }
 
-func (uri ChannelUri) SetMedia(media string) {
+func (uri *ChannelUri) SetMedia(media string) {
 	uri.media = media
 }
 


### PR DESCRIPTION
## Summary
- correct ChannelUri.SetMedia to use a pointer receiver

## Testing
- `go vet ./...` *(fails: fetching modules forbidden)*
- `go test ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6840aa6e41948321992f36f413785a02